### PR TITLE
refactor: introduce reusable tile component

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,12 @@
       </button>
     </div>
 
-    <div class="input-card">
+    <div class="tile tile--primary input-card">
+      <span class="tile-icon">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M15.232 5.232l3.536 3.536M4 20h4l10-10-4-4L4 16v4z" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </span>
       <form id="chart-form">
         <div class="form-grid">
           <div class="form-group">
@@ -76,54 +81,91 @@
       Calculating your natal chart...
     </div>
 
-    <div class="results-section" id="results-section">
-      <div class="results-header">
-        <h2 class="results-title">Your Natal Chart</h2>
+    <div id="results-section">
+      <div class="tile tile--primary">
+        <span class="tile-icon">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="5" fill="currentColor" />
+            <ellipse cx="12" cy="12" rx="9" ry="4" stroke="currentColor" fill="none" stroke-width="2" />
+          </svg>
+        </span>
+        <h3 class="tile-title">Natal Chart</h3>
+        <p class="tile-summary">Positions of the planets at your birth</p>
+        <canvas id="chart" width="500" height="500" aria-label="Natal chart" role="img"></canvas>
       </div>
-      
-      <div class="chart-container">
-        <div class="chart-wrapper">
-          <h3 class="chart-title">Natal Chart</h3>
-          <canvas id="chart" width="500" height="500" aria-label="Natal chart" role="img"></canvas>
-        </div>
-        
-        <div class="chart-wrapper">
-          <h3 class="chart-title">Moon Phase</h3>
-          <canvas id="moon-chart" width="400" height="400" aria-label="Moon phase" role="img"></canvas>
-        </div>
-        
-        <div class="chart-wrapper">
-          <h3 class="chart-title">Chinese Zodiac</h3>
-          <canvas id="chinese-zodiac-chart" width="400" height="400" aria-label="Chinese zodiac" role="img"></canvas>
+
+      <div class="tile tile--secondary">
+        <span class="tile-icon">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 0011.58 9.79z" fill="currentColor" />
+          </svg>
+        </span>
+        <h3 class="tile-title">Moon Phase</h3>
+        <p class="tile-summary">Current lunar phase</p>
+        <canvas id="moon-chart" width="400" height="400" aria-label="Moon phase" role="img"></canvas>
+      </div>
+
+      <div class="tile tile--accent">
+        <span class="tile-icon">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" />
+            <text x="12" y="16" text-anchor="middle" font-size="14" fill="currentColor">羊</text>
+          </svg>
+        </span>
+        <h3 class="tile-title">Chinese Zodiac</h3>
+        <p class="tile-summary">Year animal sign</p>
+        <canvas id="chinese-zodiac-chart" width="400" height="400" aria-label="Chinese zodiac" role="img"></canvas>
+      </div>
+
+      <div class="tile tile--primary">
+        <span class="tile-icon">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" stroke="currentColor" fill="none" stroke-width="2" />
+            <line x1="3" y1="9" x2="21" y2="9" stroke="currentColor" stroke-width="2" />
+            <line x1="3" y1="15" x2="21" y2="15" stroke="currentColor" stroke-width="2" />
+            <line x1="9" y1="3" x2="9" y2="21" stroke="currentColor" stroke-width="2" />
+            <line x1="15" y1="3" x2="15" y2="21" stroke="currentColor" stroke-width="2" />
+          </svg>
+        </span>
+        <h3 class="tile-title">Planetary Details</h3>
+        <p class="tile-summary">Table of planetary placements</p>
+        <table class="planets-table" id="planets-table">
+          <thead>
+            <tr>
+              <th>Planet</th>
+              <th>Sign</th>
+              <th>Element</th>
+              <th>Longitude</th>
+              <th>Retrograde</th>
+            </tr>
+          </thead>
+          <tbody id="planets-tbody"></tbody>
+        </table>
+      </div>
+
+      <div class="tile tile--secondary">
+        <span class="tile-icon">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 2l3 7h7l-5.5 4.5L18 22l-6-4-6 4 1.5-8.5L2 9h7z" fill="currentColor" />
+          </svg>
+        </span>
+        <h3 class="tile-title">Element Balance</h3>
+        <p class="tile-summary">Count of elements in your chart</p>
+        <div class="element-counts" id="element-counts">
+          <!-- Element counts will be populated here -->
         </div>
       </div>
-      
-              <div class="data-section">
-          <h3 class="data-title">Planetary Details</h3>
-          <table class="planets-table" id="planets-table">
-            <thead>
-              <tr>
-                <th>Planet</th>
-                <th>Sign</th>
-                <th>Element</th>
-                <th>Longitude</th>
-                <th>Retrograde</th>
-              </tr>
-            </thead>
-            <tbody id="planets-tbody"></tbody>
-          </table>
-        </div>
-        
-        <div class="data-section">
-          <h3 class="data-title">Element Balance</h3>
-          <div class="element-counts" id="element-counts">
-            <!-- Element counts will be populated here -->
-          </div>
-        </div>
     </div>
 
-    <div class="aspects-section" id="aspects-section" style="display: none;">
-      <h3 class="data-title">Major Aspects</h3>
+    <div class="tile tile--accent aspects-section" id="aspects-section" style="display: none;">
+      <span class="tile-icon">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="7" cy="12" r="3" stroke="currentColor" stroke-width="2" fill="none" />
+          <circle cx="17" cy="12" r="3" stroke="currentColor" stroke-width="2" fill="none" />
+          <line x1="10" y1="12" x2="14" y2="12" stroke="currentColor" stroke-width="2" />
+        </svg>
+      </span>
+      <h3 class="tile-title">Major Aspects</h3>
       <div class="aspects-grid" id="aspects-grid"></div>
     </div>
   </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -17,6 +17,12 @@
   --chart-aspects: #8b5cf6;
   --stars: radial-gradient(1px 1px at 20px 30px, rgba(255,255,255,0.6), transparent),
            radial-gradient(1px 1px at 40px 70px, rgba(255,255,255,0.4), transparent);
+  --tile-primary-gradient: linear-gradient(135deg, #eef2ff 0%, #e0e7ff 100%);
+  --tile-secondary-gradient: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  --tile-accent-gradient: linear-gradient(135deg, #fdf2f8 0%, #fce7f3 100%);
+  --tile-primary-border: #c7d2fe;
+  --tile-secondary-border: #e2e8f0;
+  --tile-accent-border: #fbb6ce;
 }
 
 [data-theme="dark"] {
@@ -39,6 +45,12 @@
   --chart-aspects: #a855f7;
   --stars: radial-gradient(1px 1px at 20px 30px, rgba(255,255,255,0.5), transparent),
            radial-gradient(1px 1px at 40px 70px, rgba(255,255,255,0.3), transparent);
+  --tile-primary-gradient: linear-gradient(135deg, #1e1b4b 0%, #4338ca 100%);
+  --tile-secondary-gradient: linear-gradient(135deg, #1f2937 0%, #374151 100%);
+  --tile-accent-gradient: linear-gradient(135deg, #4a044e 0%, #831843 100%);
+  --tile-primary-border: #6366f1;
+  --tile-secondary-border: #4b5563;
+  --tile-accent-border: #be123c;
 }
 
 /* =============== Layout =============== */
@@ -181,26 +193,21 @@ body::before {
   transform: rotate(180deg);
 }
 
-
-.input-card {
+/* Tile component */
+.tile {
   background: var(--bg-secondary);
   border-radius: var(--radius);
   padding: 2rem;
   box-shadow: var(--shadow);
-  margin-bottom: 2rem;
   border: 1px solid var(--border-color);
   backdrop-filter: blur(20px);
   position: relative;
   overflow: hidden;
-  transition: all 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  margin-bottom: 2rem;
 }
 
-.input-card:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-}
-
-.input-card::before {
+.tile::before {
   content: '';
   position: absolute;
   top: 0;
@@ -209,6 +216,68 @@ body::before {
   height: 2px;
   background: linear-gradient(90deg, var(--accent-primary), var(--accent-secondary));
   opacity: 0.7;
+}
+
+.tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.tile:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+.tile--primary {
+  background: var(--tile-primary-gradient);
+  border-color: var(--tile-primary-border);
+}
+
+.tile--secondary {
+  background: var(--tile-secondary-gradient);
+  border-color: var(--tile-secondary-border);
+}
+
+.tile--accent {
+  background: var(--tile-accent-gradient);
+  border-color: var(--tile-accent-border);
+}
+
+.tile--primary .tile-icon { color: var(--accent-primary); }
+.tile--secondary .tile-icon { color: var(--accent-secondary); }
+.tile--accent .tile-icon { color: #d97706; }
+
+.tile-icon {
+  position: absolute;
+  top: -24px;
+  left: 1rem;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--bg-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.tile-icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.tile-title {
+  margin-top: 1.5rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+}
+
+.tile-summary {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
 }
 
 .form-grid {
@@ -353,133 +422,22 @@ body::before {
   box-shadow: 0 4px 12px rgba(139, 92, 246, 0.4);
 }
 
-.results-section {
+#results-section {
   display: none;
-  background: var(--bg-secondary);
-  border-radius: var(--radius);
-  padding: 2rem;
-  box-shadow: var(--shadow);
-  margin-bottom: 2rem;
-  border: 1px solid var(--border-color);
-  backdrop-filter: blur(20px);
-  position: relative;
-  overflow: hidden;
-  transition: all 0.2s ease;
-  text-align: center;
-}
-
-.results-section:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-}
-
-.results-section::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--accent-primary), var(--accent-secondary));
-  opacity: 0.7;
-}
-
-.results-section.active {
-  display: block;
-}
-
-.results-header {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 2px solid var(--border-color);
-}
-
-.results-title {
-  font-size: 2rem;
-  font-weight: 800;
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
-  margin-bottom: 0.5rem;
-}
-
-[data-theme="dark"] .results-title {
-  background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 25%, #c084fc 50%, #d8b4fe 75%, #f3e8ff 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.chart-container {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
   gap: 2rem;
-  margin-bottom: 3rem;
-  align-items: start;
 }
 
-@media (max-width: 1400px) {
-  .chart-container {
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
-  }
+#results-section.active {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-@media (max-width: 900px) {
-  .chart-container {
-    grid-template-columns: 1fr;
-    gap: 2rem;
-  }
+#results-section .tile {
+  margin-bottom: 0;
 }
 
-.chart-wrapper {
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  margin-bottom: 4rem;
-}
 
-.data-section {
-  width: 100%;
-  text-align: center;
-  margin-bottom: 3rem;
-}
 
-.data-title {
-  font-size: 1.8rem;
-  font-weight: 700;
-  margin-bottom: 1.5rem;
-  color: var(--text-primary);
-  letter-spacing: -0.01em;
-}
-
-[data-theme="dark"] .data-title {
-  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 25%, #4338ca 50%, #3730a3 75%, #312e81 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.chart-title {
-  font-size: 2rem;
-  font-weight: 800;
-  margin-bottom: 2rem;
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
-}
-
-[data-theme="dark"] .chart-title {
-  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 25%, #4338ca 50%, #3730a3 75%, #312e81 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  font-weight: 700;
-}
 
 #chart {
   border: 3px solid var(--chart-border);
@@ -569,33 +527,9 @@ body::before {
 }
 
 .aspects-section {
-  background: var(--bg-secondary);
-  border-radius: var(--radius);
   padding: 3rem;
-  box-shadow: var(--shadow);
-  border: 1px solid var(--border-color);
-  backdrop-filter: blur(20px);
-  position: relative;
-  overflow: hidden;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   max-width: 800px;
   margin: 0 auto;
-}
-
-.aspects-section:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
-}
-
-.aspects-section::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--accent-primary), var(--accent-secondary));
-  opacity: 0.7;
 }
 
 .aspects-title {
@@ -805,9 +739,6 @@ body::before {
     grid-template-columns: 1fr;
   }
   
-  .chart-container {
-    grid-template-columns: 1fr;
-  }
   
   .controls {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add reusable `.tile` component with themed gradients and hover/focus states
- replace results card with responsive grid of icon tiles
- update input and aspects sections to use tile styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68a8a71624b4832abd84191661fcce37